### PR TITLE
doctype, otherwise we get crappy quirksmode

### DIFF
--- a/lib/templates/captured_browser.html
+++ b/lib/templates/captured_browser.html
@@ -1,4 +1,5 @@
-<html> 
+<!DOCTYPE html>
+<html lang="en">
   <head> 
     <title>Buster</title> 
   </head> 

--- a/lib/templates/control_frame.html
+++ b/lib/templates/control_frame.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head></head>
   <body></body>
   <% for (var i = 0, ii = scripts.length; i < ii; i++) { %>


### PR DESCRIPTION
I figured out why I couldn't find `msMatchesSelector` or even `querySelectorAll` in IE9, all tests run in quirksmode.
