### PR TITLE
Viewport meta tag for testing media queries

### DIFF
--- a/lib/templates/slave_prison.html
+++ b/lib/templates/slave_prison.html
@@ -2,6 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <title>Buster</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     {{scripts}}
   </head>
   <frameset rows="<% if (hasHeader) { %><%= headerHeight %>px,<% } %>*">


### PR DESCRIPTION
To correctly match the width of the window on mobile devices, a viewport meta tag is needed.
You could of course use device-width for this as well, but using the window width is a more generic (and in my opinion) a better approach. Besides, when optimizing content for mobile devices, this tag is usually present.

I tried injecting this tag into the testing-frame, but it didn't have any effects.

Also, the best thing would probably be to add configuration options for these kind of things when starting the server, but that's a bit over my head right now.
