### PR TITLE
Add license type according to busterjs project.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,6 @@
         "buster-node": "*",
         "sinon": ">=1.4",
         "phantom": "0.5.2"
-    }
+    },
+	"license": "BSD"
 }


### PR DESCRIPTION
This makes automatic tools like license-checker work better.
