### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "ramp-resources": "2.x",
-    "faye": "1.x",
+    "faye": "1.1.2",
     "ejs": "2.x",
     "node-uuid": "1.x",
     "when": "3.x",


### PR DESCRIPTION
faye updated to 1.2.0 on the weekend. Since then I'm getting an error when running buster :

Error: Cannot find module 'faye/browser/faye-browser-min'

So could you please use the old version in the package.json